### PR TITLE
[#48] Expose request id within parent app when using middleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.2.0
   - 2.3.3
   - 2.4.0
+  - 2.5.0
   - ruby-head
 
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file needs to be updated with every significant pull request. It is used to write down release notes.
 
 ## Version 0.5.6
-
+* Expose request id to parent Rack application when using `ApplicationInsights::Rack::TrackRequest` middleware through `env['ApplicationInsights.request.id']`
 
 ## Version 0.5.5
 * Add some basic logging when failed to send telemetry to the server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file needs to be updated with every significant pull request. It is used to
 
 ## Version 0.5.6
 * Expose request id to parent Rack application when using `ApplicationInsights::Rack::TrackRequest` middleware through `env['ApplicationInsights.request.id']`
+* Add functionality to accept a Request-Id header for telemetry correlation
 
 ## Version 0.5.5
 * Add some basic logging when failed to send telemetry to the server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 This file needs to be updated with every significant pull request. It is used to write down release notes.
 
 ## Version 0.5.6
-* Expose request id to parent Rack application when using `ApplicationInsights::Rack::TrackRequest` middleware through `env['ApplicationInsights.request.id']`
-* Implement operation context functionality for `ApplicationInsights::Rack::TrackRequest`
-* Add functionality to accept a Request-Id header for telemetry correlation
+* Expose request id to parent Rack application when using `ApplicationInsights::Rack::TrackRequest` middleware through `env['ApplicationInsights.request.id']`.
+* Implement operation context functionality for `ApplicationInsights::Rack::TrackRequest`.
+* Add functionality to accept a Request-Id header for telemetry correlation.
+* Add functionality to populate Request-Id header in response.
+* Add operation context to request tracking middleware.
 
 ## Version 0.5.5
 * Add some basic logging when failed to send telemetry to the server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This file needs to be updated with every significant pull request. It is used to
 * Expose request id to parent Rack application when using `ApplicationInsights::Rack::TrackRequest` middleware through `env['ApplicationInsights.request.id']`.
 * Implement operation context functionality for `ApplicationInsights::Rack::TrackRequest`.
 * Add functionality to accept a Request-Id header for telemetry correlation.
-* Add functionality to populate Request-Id header in response.
 * Add operation context to request tracking middleware.
 
 ## Version 0.5.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This file needs to be updated with every significant pull request. It is used to
 
 ## Version 0.5.6
 * Expose request id to parent Rack application when using `ApplicationInsights::Rack::TrackRequest` middleware through `env['ApplicationInsights.request.id']`
+* Implement operation context functionality for `ApplicationInsights::Rack::TrackRequest`
 * Add functionality to accept a Request-Id header for telemetry correlation
 
 ## Version 0.5.5

--- a/README.md
+++ b/README.md
@@ -146,16 +146,16 @@ use ApplicationInsights::Rack::TrackRequest, '<YOUR INSTRUMENTATION KEY GOES HER
 config.middleware.use 'ApplicationInsights::Rack::TrackRequest', '<YOUR INSTRUMENTATION KEY GOES HERE>', <buffer size>
 ```
 
-#### Retrieving a request's AppInsight ID  ####
+#### Rerieving the Request-Id value from ApplicationInsights ####
 ```ruby
-# from time to time you may need to access a request's AppInsight id from within your app
+# from time to time you may need to access a request's id from within your app
 application_insights_request_id = env['ApplicationInsights.request.id']
 
 # this can be used for a number of different purposes, including telemetry correlation
 uri = URI('http://api.example.com/search/?q=test')
 
 req = Net::HTTP::Get.new(uri)
-req['Request-Id'] = "|#{application_insights_request_id}." if application_insights_request_id
+req['Request-Id'] = "#{application_insights_request_id}1" if application_insights_request_id
 
 Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
 ```

--- a/README.md
+++ b/README.md
@@ -145,3 +145,17 @@ use ApplicationInsights::Rack::TrackRequest, '<YOUR INSTRUMENTATION KEY GOES HER
 # For rails, suggest to set up this middleware in application.rb so that unhandled exceptions from controllers are also collected
 config.middleware.use 'ApplicationInsights::Rack::TrackRequest', '<YOUR INSTRUMENTATION KEY GOES HERE>', <buffer size>
 ```
+
+#### Retrieving a request's AppInsight ID  ####
+```ruby
+# from time to time you may need to access a request's AppInsight id from within your app
+application_insights_request_id = env['ApplicationInsights.request.id']
+
+# this can be used for a number of different purposes, including telemetry correlation
+uri = URI('http://api.example.com/search/?q=test')
+
+req = Net::HTTP::Get.new(uri)
+req['Request-Id'] = "|#{application_insights_request_id}." if application_insights_request_id
+
+Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+```

--- a/application_insights.gemspec
+++ b/application_insights.gemspec
@@ -25,4 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'redcarpet', '~> 3.2.2'
   spec.add_development_dependency 'rack', '>= 1.0.0'
   spec.add_development_dependency 'test-unit', '~> 3.0.8'
+  spec.add_development_dependency 'mocha', '~> 1.5.0'
+
 end

--- a/lib/application_insights/channel/contracts/operation.rb
+++ b/lib/application_insights/channel/contracts/operation.rb
@@ -13,7 +13,7 @@ module ApplicationInsights::Channel::Contracts
       root_id: 'ai.operation.rootId',
       synthetic_source: 'ai.operation.syntheticSource',
       is_synthetic: 'ai.operation.isSynthetic',
-      correlation_vector: "ai.operation.correlationVector"
+      correlation_vector: 'ai.operation.correlationVector'
     )
   end
 end

--- a/lib/application_insights/channel/queue_base.rb
+++ b/lib/application_insights/channel/queue_base.rb
@@ -13,7 +13,7 @@ module ApplicationInsights
       def initialize(sender)
         @queue = Queue.new
         @max_queue_length = 500
-        setup_sender(sender)
+        self.sender = sender
       end
 
       # The maximum number of items that will be held by the queue before the
@@ -30,7 +30,9 @@ module ApplicationInsights
       # @param [SenderBase] sender the sender object.
       # @return [SenderBase] the sender object.
       def sender=(sender)
-        setup_sender(sender)
+        @sender = sender
+        @sender.queue = self if sender
+        @sender
       end
 
       # Adds the passed in item object to the queue and calls {#flush} if the
@@ -65,18 +67,6 @@ module ApplicationInsights
       # @return [Boolean] true if the queue is empty
       def empty?
         @queue.empty?
-      end
-
-      private
-
-      # Populate @sender and configure it's queue.
-      # @param [SenderBase] sender the sender object.
-      # @return [SenderBase] the sender object.
-      def setup_sender(sender)
-        @sender = sender
-        @sender.queue = self if sender
-
-        @sender
       end
     end
   end

--- a/lib/application_insights/channel/queue_base.rb
+++ b/lib/application_insights/channel/queue_base.rb
@@ -13,8 +13,7 @@ module ApplicationInsights
       def initialize(sender)
         @queue = Queue.new
         @max_queue_length = 500
-        @sender = sender
-        @sender.queue = self if sender
+        setup_sender(sender)
       end
 
       # The maximum number of items that will be held by the queue before the
@@ -26,6 +25,13 @@ module ApplicationInsights
       # send data to the service.
       # @return [SenderBase] the sender object.
       attr_reader :sender
+
+      # Change the sender that is associated with this queue.
+      # @param [SenderBase] sender the sender object.
+      # @return [SenderBase] the sender object.
+      def sender=(sender)
+        setup_sender(sender)
+      end
 
       # Adds the passed in item object to the queue and calls {#flush} if the
       # size of the queue is larger than {#max_queue_length}. This method does
@@ -59,6 +65,18 @@ module ApplicationInsights
       # @return [Boolean] true if the queue is empty
       def empty?
         @queue.empty?
+      end
+
+      private
+
+      # Populate @sender and configure it's queue.
+      # @param [SenderBase] sender the sender object.
+      # @return [SenderBase] the sender object.
+      def setup_sender(sender)
+        @sender = sender
+        @sender.queue = self if sender
+
+        @sender
       end
     end
   end

--- a/lib/application_insights/rack/track_request.rb
+++ b/lib/application_insights/rack/track_request.rb
@@ -24,6 +24,9 @@ module ApplicationInsights
       # Track requests and send data to Application Insights asynchronously.
       # @param [Hash] env the rack environment.
       def call(env)
+        id = rand(16**32).to_s(16)
+        env['ApplicationInsights.request.id'] = id
+
         start = Time.now
         begin
           status, headers, response = @app.call(env)
@@ -44,7 +47,6 @@ module ApplicationInsights
         end
 
         request = ::Rack::Request.new env
-        id = rand(16**32).to_s(16)
         start_time = start.iso8601(7)
         duration = format_request_duration(stop - start)
         success = status.to_i < 400

--- a/lib/application_insights/rack/track_request.rb
+++ b/lib/application_insights/rack/track_request.rb
@@ -20,6 +20,14 @@ module ApplicationInsights
         @instrumentation_key = instrumentation_key
         @buffer_size = buffer_size
         @send_interval = send_interval
+
+        @sender = Channel::AsynchronousSender.new
+        @sender.send_interval = @send_interval
+        queue = Channel::AsynchronousQueue.new @sender
+        queue.max_queue_length = @buffer_size
+        @channel = Channel::TelemetryChannel.new nil, queue
+
+        @client = TelemetryClient.new @instrumentation_key, @channel
       end
 
       # Track requests and send data to Application Insights asynchronously.
@@ -36,10 +44,6 @@ module ApplicationInsights
         request_id = request_id_header(env['HTTP_REQUEST_ID'])
         env['ApplicationInsights.request.id'] = request_id
 
-        log_message = valid_request_id(env['HTTP_REQUEST_ID']) ? 'Operation' : 'Incoming request'
-        log_message = "#{log_message} started with Request-Id: #{request_id}"
-        puts log_message
-
         start = Time.now
         begin
           status, headers, response = @app.call(env)
@@ -52,29 +56,17 @@ module ApplicationInsights
         end
         stop = Time.now
 
-        sender = @sender || Channel::AsynchronousSender.new
-        sender.send_interval = @send_interval
-        queue = Channel::AsynchronousQueue.new sender
-        queue.max_queue_length = @buffer_size
-        channel = Channel::TelemetryChannel.new nil, queue
-
-        @client = TelemetryClient.new @instrumentation_key, channel
-
-        request = ::Rack::Request.new env
         start_time = start.iso8601(7)
         duration = format_request_duration(stop - start)
         success = status.to_i < 400
-        options = {
-          :name => "#{request.request_method} #{request.path}",
-          :http_method => request.request_method,
-          :url => request.url
-        }
 
-        # Setup operation context
-        @client.context.operation.id = operation_id(request_id)
-        @client.context.operation.parent_id = env['HTTP_REQUEST_ID']
+        request = ::Rack::Request.new env
+        options = options_hash(request)
 
-        @client.track_request request_id, start_time, duration, status, success, options
+        data = request_data(request_id, start_time, duration, status, success, options)
+        context = telemetry_context(request_id, env['HTTP_REQUEST_ID'])
+
+        @client.channel.write data, context, start_time
 
         if exception
           @client.track_exception exception, handled_at: 'Unhandled'
@@ -87,7 +79,10 @@ module ApplicationInsights
       private
 
       def sender=(sender)
-        @sender = sender if sender.is_a? Channel::AsynchronousSender
+        if sender.is_a? Channel::AsynchronousSender
+          @sender = sender
+          @client.channel.queue.sender = @sender
+        end
       end
 
       def client
@@ -131,6 +126,38 @@ module ApplicationInsights
         root_end = root_end ? root_end - 1 : id.length - root_start
 
         id[root_start..root_end]
+      end
+
+      def options_hash(request)
+        {
+            name: "#{request.request_method} #{request.path}",
+            http_method: request.request_method,
+            url: request.url
+        }
+      end
+
+      def request_data(request_id, start_time, duration, status, success, options)
+        Channel::Contracts::RequestData.new(
+            :id => request_id || 'Null',
+            :start_time => start_time || Time.now.iso8601(7),
+            :duration => duration || '0:00:00:00.0000000',
+            :response_code => status || 200,
+            :success => success == nil ? true : success,
+            :name => options[:name],
+            :http_method => options[:http_method],
+            :url => options[:url],
+            :properties => options[:properties] || {},
+            :measurements => options[:measurements] || {}
+        )
+      end
+
+      def telemetry_context(request_id, request_id_header)
+        context = Channel::TelemetryContext.new
+        context.instrumentation_key = @instrumentation_key
+        context.operation.id = operation_id(request_id)
+        context.operation.parent_id = request_id_header
+
+        context
       end
     end
   end

--- a/lib/application_insights/rack/track_request.rb
+++ b/lib/application_insights/rack/track_request.rb
@@ -33,13 +33,6 @@ module ApplicationInsights
       # Track requests and send data to Application Insights asynchronously.
       # @param [Hash] env the rack environment.
       def call(env)
-        # Create a duplicate of the middleware for each request to ensure thread safety
-        dup._call(env)
-      end
-
-      # Track requests and send data to Application Insights asynchronously.
-      # @param [Hash] env the rack environment.
-      def _call(env)
         # Build a request ID, incorporating one from our request if one exists.
         request_id = request_id_header(env['HTTP_REQUEST_ID'])
         env['ApplicationInsights.request.id'] = request_id
@@ -47,9 +40,6 @@ module ApplicationInsights
         start = Time.now
         begin
           status, headers, response = @app.call(env)
-
-          # Set a Request-Id response header if one has not been set within our app
-          headers['Request-Id'] ||= request_id
         rescue Exception => ex
           status = 500
           exception = ex

--- a/lib/application_insights/rack/track_request.rb
+++ b/lib/application_insights/rack/track_request.rb
@@ -58,6 +58,10 @@ module ApplicationInsights
           :url => request.url
         }
 
+        # Setup operation context
+        @client.context.operation.id = operation_id(request_id)
+        @client.context.operation.parent_id = request_id
+
         @client.track_request request_id, start_time, duration, status, success, options
 
         if exception
@@ -102,6 +106,16 @@ module ApplicationInsights
         end
 
         "|#{id}."
+      end
+
+      def operation_id(id)
+        # Returns the root ID from the '|' to the first '.' if any.
+        root_end = id.index('.')
+        root_end = id.length if root_end.nil?
+
+        root_start = id[0] == '|' ? 1 : 0
+
+        id[root_start..root_end - root_start]
       end
     end
   end

--- a/lib/application_insights/version.rb
+++ b/lib/application_insights/version.rb
@@ -1,3 +1,3 @@
 module ApplicationInsights
-  VERSION = '0.5.6'
+  VERSION = '0.5.6'.freeze
 end

--- a/test/application_insights/rack/test_track_request.rb
+++ b/test/application_insights/rack/test_track_request.rb
@@ -36,6 +36,8 @@ class TestTrackRequest < Test::Unit::TestCase
     assert_equal url, request_data.url
     assert_equal true, request_data.duration.start_with?("00.00:00:02")
     assert Time.parse(request_data.start_time) - start_time < 0.01
+
+    assert env['ApplicationInsights.request.id']  =~ (/^\h{1,32}$/)
   end
 
   def test_call_with_failed_request
@@ -54,6 +56,8 @@ class TestTrackRequest < Test::Unit::TestCase
     payload = sender.buffer[0]
     request_data = payload[0].data.base_data
     assert_equal false, request_data.success
+
+    assert env['ApplicationInsights.request.id']  =~ (/^\h{1,32}$/)
   end
 
   def test_call_with_unhandled_exception
@@ -80,6 +84,8 @@ class TestTrackRequest < Test::Unit::TestCase
     exception_data = payload[1].data.base_data
     assert_equal instrumentation_key, payload[1].i_key
     assert_equal 'Unhandled', exception_data.handled_at
+
+    assert env['ApplicationInsights.request.id']  =~ (/^\h{1,32}$/)
   end
 
   def test_internal_client


### PR DESCRIPTION
* Update TravisCI testing matrix
* Update CHANGELOG
* Update README
* Update `ApplicationInsights::Rack::TrackRequest#call` to implement the above
* Add associated tests
* Support receiving a Request-Id header
* Updated `ApplicationInsights::Rack::TrackRequest` to generate variable length IDs
  * When generating a new ID, 16 characters is used
  * When appending a new ID, 8 characters is used
* Update `ApplicationInsights::Rack::TrackRequest` to call `@client.channel.write` directly to allow for sending of operation IDs
* Updated `ApplicationInsights::Rack::TrackRequest` to share `@client` across requests

Fixes [#48]