### PR TITLE
Correct classname autoloaded

### DIFF
--- a/lib/application_insights.rb
+++ b/lib/application_insights.rb
@@ -5,6 +5,6 @@ require_relative 'application_insights/version'
 module ApplicationInsights
   module Rack
     autoload :TrackRequest, "application_insights/rack/track_request"
-    autoload :TrackPageView, "application_insights/rack/track_page_view"
+    autoload :InjectJavaScriptTracking, "application_insights/rack/track_page_view"
   end
 end

--- a/test/application_insights/rack/test_inject_java_script_tracking.rb
+++ b/test/application_insights/rack/test_inject_java_script_tracking.rb
@@ -4,7 +4,7 @@ require_relative '../../../lib/application_insights/rack/inject_java_script_trac
 
 include ApplicationInsights::Rack
 
-class TestInjectScriptTrackingView < Test::Unit::TestCase
+class TestInjectJavaScriptTracking < Test::Unit::TestCase
   def test_embeds_tracking_script_into_html_content
     app = generate_dummy_app(body: <<-'BODY'
       <html>


### PR DESCRIPTION
This pull request provides a small patch to rename a class name to be `autoload`ed. 

Ref. https://github.com/Microsoft/ApplicationInsights-Ruby/pull/64#discussion_r245176651