### PR TITLE
Fix test fails in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ rvm:
 cache: bundler
 
 before_install:
-  - gem install bundler
+  - gem install bundler -v 1.17.3
 
 matrix:
   allow_failures:

--- a/lib/application_insights/rack/inject_java_script_tracking.rb
+++ b/lib/application_insights/rack/inject_java_script_tracking.rb
@@ -29,7 +29,7 @@ module ApplicationInsights
 
       private
       def embedded_script_code
-        <<~"SCRIPT"
+        <<-"SCRIPT"
           <script type="text/javascript">
           var appInsights=window.appInsights||function(a){
             function b(a){c[a]=function(){var b=arguments;c.queue.push(function(){c[a].apply(c,b)})}}var c={config:a},d=document,e=window;setTimeout(function(){var b=d.createElement("script");b.src=a.url||"https://az416426.vo.msecnd.net/scripts/a/ai.0.js",d.getElementsByTagName("script")[0].parentNode.appendChild(b)});try{c.cookie=d.cookie}catch(a){}c.queue=[];for(var f=["Event","Exception","Metric","PageView","Trace","Dependency"];f.length;)b("track"+f.pop());if(b("setAuthenticatedUserContext"),b("clearAuthenticatedUserContext"),b("startTrackEvent"),b("stopTrackEvent"),b("startTrackPage"),b("stopTrackPage"),b("flush"),!a.disableExceptionTracking){f="onerror",b("_"+f);var g=e[f];e[f]=function(a,b,d,e,h){var i=g&&g(a,b,d,e,h);return!0!==i&&c["_"+f](a,b,d,e,h),i}}return c

--- a/test/application_insights/rack/test_inject_java_script_tracking.rb
+++ b/test/application_insights/rack/test_inject_java_script_tracking.rb
@@ -73,7 +73,10 @@ class TestInjectScriptTrackingView < Test::Unit::TestCase
   end
 
   private
-    def generate_dummy_app(status: 200, headers: {}, body:)
+    def generate_dummy_app(args)
+      status = args[:status] || 200
+      headers = args[:headers] || {}
+      body = args[:body]
       unless headers.key?('Content-Type')
         headers['Content-Type'] = 'text/html'
       end


### PR DESCRIPTION
[The current develop branch doesn't pass the tests](https://travis-ci.org/Microsoft/ApplicationInsights-Ruby/builds/475109693) because of two issues: 

1. `.travis.yml` attempts to install the latest version of bunlder but the current latest version(2.0.1) requires ruby version 2.3 or later. 
2. tests introduced in #64 use some syntaxes not in old rubies. 

This pull-request resolves the issues to keep supporting ruby version 1.9.3 or later. 