### PR TITLE
Fix autoload path name

### DIFF
--- a/lib/application_insights.rb
+++ b/lib/application_insights.rb
@@ -5,6 +5,6 @@ require_relative 'application_insights/version'
 module ApplicationInsights
   module Rack
     autoload :TrackRequest, "application_insights/rack/track_request"
-    autoload :InjectJavaScriptTracking, "application_insights/rack/track_page_view"
+    autoload :InjectJavaScriptTracking, "application_insights/rack/inject_java_script_tracking"
   end
 end

--- a/test/application_insights/rack/test_inject_java_script_tracking.rb
+++ b/test/application_insights/rack/test_inject_java_script_tracking.rb
@@ -1,6 +1,6 @@
 require 'test/unit'
 require 'rack/mock'
-require_relative '../../../lib/application_insights/rack/inject_java_script_tracking'
+require_relative '../../../lib/application_insights'
 
 include ApplicationInsights::Rack
 


### PR DESCRIPTION
`autoload InjectJavaScriptTracking` still fails as its path is not correct. This pull-request is to fix it.