### PR TITLE
Add parameter to optionally send IP address

### DIFF
--- a/lib/application_insights/channel/contracts/reopenings.rb
+++ b/lib/application_insights/channel/contracts/reopenings.rb
@@ -23,5 +23,17 @@ module ApplicationInsights::Channel::Contracts
                 @properties["httpMethod"] = http_method
             end
         end
+
+        def client_ip
+            @properties["clientIp"] if @properties
+        end
+
+        def client_ip=(client_ip)
+            if client_ip
+                @properties ||= {}
+                @properties["clientIp"] = client_ip
+            end
+        end
+
     end
 end


### PR DESCRIPTION
In February last year, Microsoft removed logging of the IP address. In some cases this is necessary (for example, to analyse requests after a security breach, or fraud attempt), and doesn't go against GDPR, as long as the user is notified, and data is deleted after a sensible time period. There is some documentation about how to do this, but this only covers .NET

This PR adds an optional parameter to turn on IP logging, adding a `clientIP` parameter to the `customProperties` field in Application Insights.