### PR TITLE
Add proxy support for telemetry client

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,3 +162,19 @@ req['Request-Id'] = "#{application_insights_request_id}1" if application_insight
 
 Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
 ```
+
+### Configuring Telemetry client with Proxy endpoint ###
+```ruby
+require 'application_insights'
+# if proxy server doesnt have authentication, provide arbitrary username and password
+# <proxyhost> : Address or FQDN of the proxy server
+# <port> : port number for the proxy server
+proxy = { :addr => '<proxyhost>', :port => '<port>', :user: '<user>', :pass: '<password>' }
+sender = ApplicationInsights::Channel::AsynchronousSender.new 'https://dc.services.visualstudio.com/v2/track', proxy
+queue = ApplicationInsights::Channel::AsynchronousQueue.new sender
+channel = ApplicationInsights::Channel::TelemetryChannel.new nil, queue
+tc = ApplicationInsights::TelemetryClient.new '<YOUR INSTRUMENTATION KEY GOES HERE>', channel
+# Note: the event will be sent on a separate thread; if the app finishes before
+#       the thread finishes, the data is lost
+tc.track_event 'My event'
+```

--- a/lib/application_insights/channel/asynchronous_sender.rb
+++ b/lib/application_insights/channel/asynchronous_sender.rb
@@ -20,15 +20,16 @@ module ApplicationInsights
       SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
-      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI)
+      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
         @send_interval = 1.0
         @send_remaining_time = 0
         @send_time = 3.0
         @lock_work_thread = Mutex.new
         @work_thread = nil
         @start_notification_processed = true
-        super service_endpoint_uri
+        super service_endpoint_uri, proxy
       end
 
       # The time span in seconds at which the the worker thread will check the

--- a/lib/application_insights/channel/asynchronous_sender.rb
+++ b/lib/application_insights/channel/asynchronous_sender.rb
@@ -23,6 +23,10 @@ module ApplicationInsights
       # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
       def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
+        # callers which requires proxy dont require to maintain service endpoint uri which potentially can change
+        if service_endpoint_uri.nil? || service_endpoint_uri.empty?
+          service_endpoint_uri = SERVICE_ENDPOINT_URI
+        end
         @send_interval = 1.0
         @send_remaining_time = 0
         @send_time = 3.0

--- a/lib/application_insights/channel/sender_base.rb
+++ b/lib/application_insights/channel/sender_base.rb
@@ -55,7 +55,7 @@ module ApplicationInsights
         headers = {
           'Accept' => 'application/json',
           'Content-Type' => 'application/json; charset=utf-8',
-          'Content-Encoding' => 'gzip',
+          'Content-Encoding' => 'gzip'
         }
         request = Net::HTTP::Post.new(uri.path, headers)
 

--- a/lib/application_insights/channel/sender_base.rb
+++ b/lib/application_insights/channel/sender_base.rb
@@ -16,12 +16,14 @@ module ApplicationInsights
     class SenderBase
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       #   telemetry data to.
-      def initialize(service_endpoint_uri)
+      def initialize(service_endpoint_uri, proxy = {})
         @service_endpoint_uri = service_endpoint_uri
         @queue = nil
         @send_buffer_size = 100
         @logger = Logger.new(STDOUT)
+        @proxy = proxy
       end
 
       # The service endpoint URI where this sender will send data to.
@@ -60,7 +62,11 @@ module ApplicationInsights
         compressed_data = compress(json)
         request.body = compressed_data
 
-        http = Net::HTTP.new uri.hostname, uri.port
+        if @proxy.nil? || @proxy.empty?
+          http = Net::HTTP.new uri.hostname, uri.port
+        else
+          http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
+        end
         if uri.scheme.downcase == 'https'
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/application_insights/channel/sender_base.rb
+++ b/lib/application_insights/channel/sender_base.rb
@@ -1,9 +1,9 @@
-require "json"
-require "net/http"
-require "openssl"
-require "stringio"
-require "zlib"
-require "logger"
+require 'json'
+require 'net/http'
+require 'openssl'
+require 'stringio'
+require 'zlib'
+require 'logger'
 
 module ApplicationInsights
   module Channel
@@ -53,9 +53,9 @@ module ApplicationInsights
       def send(data_to_send)
         uri = URI(@service_endpoint_uri)
         headers = {
-          "Accept" => "application/json",
-          "Content-Type" => "application/json; charset=utf-8",
-          "Content-Encoding" => "gzip",
+          'Accept' => 'application/json',
+          'Content-Type' => 'application/json; charset=utf-8',
+          'Content-Encoding' => 'gzip',
         }
         request = Net::HTTP::Post.new(uri.path, headers)
 
@@ -70,7 +70,7 @@ module ApplicationInsights
         else
           http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
         end
-        if uri.scheme.downcase == "https"
+        if uri.scheme.downcase == 'https'
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
@@ -79,7 +79,7 @@ module ApplicationInsights
         http.finish if http.started?
 
         if !response.kind_of? Net::HTTPSuccess
-          @logger.warn("application_insights") { "Failed to send data: #{response.message}" }
+          @logger.warn('application_insights') { "Failed to send data: #{response.message}" }
         end
       end
 

--- a/lib/application_insights/channel/sender_base.rb
+++ b/lib/application_insights/channel/sender_base.rb
@@ -1,9 +1,9 @@
-require 'json'
-require 'net/http'
-require 'openssl'
-require 'stringio'
-require 'zlib'
-require 'logger'
+require "json"
+require "net/http"
+require "openssl"
+require "stringio"
+require "zlib"
+require "logger"
 
 module ApplicationInsights
   module Channel
@@ -43,6 +43,9 @@ module ApplicationInsights
       # The logger for the sender.
       attr_accessor :logger
 
+      # The proxy for the sender.
+      attr_accessor :proxy
+
       # Immediately sends the data passed in to {#service_endpoint_uri}. If the
       # service request fails, the passed in items are pushed back to the {#queue}.
       # @param [Array<Contracts::Envelope>] data_to_send an array of
@@ -50,9 +53,9 @@ module ApplicationInsights
       def send(data_to_send)
         uri = URI(@service_endpoint_uri)
         headers = {
-          'Accept' => 'application/json',
-          'Content-Type' => 'application/json; charset=utf-8',
-          'Content-Encoding' => 'gzip'
+          "Accept" => "application/json",
+          "Content-Type" => "application/json; charset=utf-8",
+          "Content-Encoding" => "gzip",
         }
         request = Net::HTTP::Post.new(uri.path, headers)
 
@@ -67,7 +70,7 @@ module ApplicationInsights
         else
           http = Net::HTTP.new(uri.hostname, uri.port, @proxy[:addr], @proxy[:port], @proxy[:user], @proxy[:pass])
         end
-        if uri.scheme.downcase == 'https'
+        if uri.scheme.downcase == "https"
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
         end
@@ -76,7 +79,7 @@ module ApplicationInsights
         http.finish if http.started?
 
         if !response.kind_of? Net::HTTPSuccess
-          @logger.warn('application_insights') { "Failed to send data: #{response.message}" }
+          @logger.warn("application_insights") { "Failed to send data: #{response.message}" }
         end
       end
 

--- a/lib/application_insights/channel/synchronous_sender.rb
+++ b/lib/application_insights/channel/synchronous_sender.rb
@@ -1,4 +1,4 @@
-require_relative 'sender_base'
+require_relative "sender_base"
 
 module ApplicationInsights
   module Channel
@@ -8,9 +8,10 @@ module ApplicationInsights
       SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
+      # @param [Hash] proxy server configuration to send (optional)
       # telemetry data to.
-      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI)
-        super service_endpoint_uri
+      def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
+        super service_endpoint_uri, proxy
       end
     end
   end

--- a/lib/application_insights/channel/synchronous_sender.rb
+++ b/lib/application_insights/channel/synchronous_sender.rb
@@ -5,12 +5,16 @@ module ApplicationInsights
     # A synchronous sender that works in conjunction with the {SynchronousQueue}.
     # The queue will call {#send} on the current instance with the data to send.
     class SynchronousSender < SenderBase
-      SERVICE_ENDPOINT_URI = 'https://dc.services.visualstudio.com/v2/track'
+      SERVICE_ENDPOINT_URI = "https://dc.services.visualstudio.com/v2/track"
       # Initializes a new instance of the class.
       # @param [String] service_endpoint_uri the address of the service to send
       # @param [Hash] proxy server configuration to send (optional)
       # telemetry data to.
       def initialize(service_endpoint_uri = SERVICE_ENDPOINT_URI, proxy = {})
+        # callers which requires proxy dont require to maintain service endpoint uri which potentially can change
+        if service_endpoint_uri.nil? || service_endpoint_uri.empty?
+          service_endpoint_uri = SERVICE_ENDPOINT_URI
+        end
         super service_endpoint_uri, proxy
       end
     end

--- a/lib/application_insights/channel/synchronous_sender.rb
+++ b/lib/application_insights/channel/synchronous_sender.rb
@@ -1,4 +1,4 @@
-require_relative "sender_base"
+require_relative 'sender_base'
 
 module ApplicationInsights
   module Channel


### PR DESCRIPTION
Add proxy support for telemetry client so that telemetry client outbound requests can be routed via proxy if the proxy configuration provided.